### PR TITLE
small fixes

### DIFF
--- a/HarmlessScript.lua
+++ b/HarmlessScript.lua
@@ -608,7 +608,7 @@ function playerRegenTab()
 end
 
 script.register_looped("HS Health Regeneration", function(healthLoop)
-  if healthCB and ENTITY.GET_ENTITY_HEALTH(PLAYER.PLAYER_PED_ID()) < ENTITY.GET_ENTITY_MAX_HEALTH(PLAYER.PLAYER_PED_ID()) then
+  if healthCB and ENTITY.GET_ENTITY_HEALTH(PLAYER.PLAYER_PED_ID()) < ENTITY.GET_ENTITY_MAX_HEALTH(PLAYER.PLAYER_PED_ID()) and PLAYER.IS_PLAYER_DEAD(PLAYER.PLAYER_ID()) == false then
     HSConsoleLogDebug("Adding " .. healthhealamount .. " amount health")
     local health = ENTITY.GET_ENTITY_HEALTH(PLAYER.PLAYER_PED_ID())
     if ENTITY.GET_ENTITY_MAX_HEALTH(PLAYER.PLAYER_PED_ID()) == health then return end
@@ -618,7 +618,7 @@ script.register_looped("HS Health Regeneration", function(healthLoop)
 end)
 
 script.register_looped("HS Armour Regeneration", function(armorLoop)
-  if armourCB and PED.GET_PED_ARMOUR(PLAYER.PLAYER_PED_ID()) < PLAYER.GET_PLAYER_MAX_ARMOUR(PLAYER.PLAYER_ID()) then
+  if armourCB and PED.GET_PED_ARMOUR(PLAYER.PLAYER_PED_ID()) < PLAYER.GET_PLAYER_MAX_ARMOUR(PLAYER.PLAYER_ID()) and PLAYER.IS_PLAYER_DEAD(PLAYER.PLAYER_ID()) == false then
     HSConsoleLogDebug("Adding " .. armourhealamount .. " amount armor")
     PED.ADD_ARMOUR_TO_PED(PLAYER.PLAYER_PED_ID(), armourhealamount)
     armorLoop:sleep(math.floor(armourregenspeed * 1000)) -- 1ms * 1000 to get seconds

--- a/HarmlessScript.lua
+++ b/HarmlessScript.lua
@@ -1,7 +1,7 @@
 --[[
   Harmless's Scripts
   Description: Harmless's Scripts is a collection of scripts made by Harmless.
-  Version: 1.2.0
+  Version: 1.2.1
 ]]--
 
 gui.show_message("Harmless's Scripts", "Harmless's Scripts loaded successfully!")
@@ -510,7 +510,7 @@ end
 
 ]]--
 HSTab:add_imgui(function()
-  ImGui.Text("Version: 1.2.0")
+  ImGui.Text("Version: 1.2.1")
   ImGui.Text("Github:")
   ImGui.SameLine(); ImGui.TextColored(0.8, 0.9, 1, 1, "YimMenu-Lua/Harmless-Scripts")
   if ImGui.IsItemHovered() and ImGui.IsItemClicked(0) then
@@ -521,31 +521,19 @@ HSTab:add_imgui(function()
   HSshowTooltip("Click to copy to clipboard")
   ImGui.Separator()
   if ImGui.Button("Changelog") then
-    ImGui.OpenPopup("  Version 1.2.0")
+    ImGui.OpenPopup("  Version 1.2.1")
   end
-  if ImGui.BeginPopupModal("  Version 1.2.0", true, ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize) then
+  if ImGui.BeginPopupModal("  Version 1.2.1", true, ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize) then
     local centerX, centerY = GetScreenCenter()
     ImGui.SetWindowPos(centerX - 300, centerY - 200)
-    ImGui.SetWindowSize(600, 400)
-    ImGui.Text("Added:")
-    ImGui.TextWrapped("+ Config system :O yay!!! - Your settings will be saved and loaded on the next launch now!")
-    ImGui.TextWrapped("+ Experimental custom tooltip - Enabled by default so people can try it out. Any feedback would be greatly appreciated. (Settings Tab)")
-    ImGui.TextWrapped("+ ESP Tracers and Color (Misc Tab)")
-    ImGui.TextWrapped("+ Radar zoom and expanded radar (HUD Tab)")
-    ImGui.TextWrapped("+ The ability to view the changelog inside YimMenu (Harmless's Scripts Tab)")
-    ImGui.TextWrapped("+ A LOT of new functions to minimize and simplify the amount of code used (Dev stuff)")
-    ImGui.TextWrapped("+ Built-in JSON library for config system (Dev stuff)")
+    ImGui.SetWindowSize(600, 300)
     ImGui.Text("Fixed:")
-    ImGui.TextWrapped("* Armor regeneration not working")
-    ImGui.TextWrapped("* NPC ESP Tab not being visible and accessible")
+    ImGui.TextWrapped("* Fixed a bug where after using ragdoll loop, the player would be stuck in ragdoll state. [By xesdoog on GitHub]")
+    ImGui.TextWrapped("* Execution moved under checkbox, removed unnecessary loop causing immediate minimap hide in GTA Online. [By xesdoog on GitHub]")
+    ImGui.TextWrapped("* Fixed a bug in \"Walk on Air\". The first time it was run, the \"air model\" was not loaded before use.")
+    ImGui.TextWrapped("* Fixed a bug where regeneration worked even when the player was dead and loading into the game.")
     ImGui.Text("Changed:")
-    ImGui.TextWrapped("~ Harmless's Scripts tab had the old URL links to this script")
-    ImGui.TextWrapped("~ Quick Options buttons have been compacted to improve visibility (Quick Options Tab)")
-    ImGui.TextWrapped("~ Notifications (info, warn, error) have been separated into individual toggles (Settings Tab)")
-    ImGui.TextWrapped("~ Compacted ImGui functions (Dev stuff)")
-    -- if ImGui.Button("Close") then
-    --     ImGui.CloseCurrentPopup()
-    -- end
+    ImGui.TextWrapped("~ Disabled the [close] button at the bottom of the window (Now there's a X at the top) [By xesdoog on GitHub]")
     ImGui.EndPopup()
   end
   ImGui.Separator()
@@ -608,7 +596,7 @@ function playerRegenTab()
 end
 
 script.register_looped("HS Health Regeneration", function(healthLoop)
-  if healthCB and ENTITY.GET_ENTITY_HEALTH(PLAYER.PLAYER_PED_ID()) < ENTITY.GET_ENTITY_MAX_HEALTH(PLAYER.PLAYER_PED_ID()) and PLAYER.IS_PLAYER_DEAD(PLAYER.PLAYER_ID()) == false then
+  if healthCB and ENTITY.GET_ENTITY_HEALTH(PLAYER.PLAYER_PED_ID()) < ENTITY.GET_ENTITY_MAX_HEALTH(PLAYER.PLAYER_PED_ID()) and PLAYER.IS_PLAYER_DEAD(PLAYER.PLAYER_ID()) == false and HUD.BUSYSPINNER_IS_ON() == false then
     HSConsoleLogDebug("Adding " .. healthhealamount .. " amount health")
     local health = ENTITY.GET_ENTITY_HEALTH(PLAYER.PLAYER_PED_ID())
     if ENTITY.GET_ENTITY_MAX_HEALTH(PLAYER.PLAYER_PED_ID()) == health then return end
@@ -618,7 +606,7 @@ script.register_looped("HS Health Regeneration", function(healthLoop)
 end)
 
 script.register_looped("HS Armour Regeneration", function(armorLoop)
-  if armourCB and PED.GET_PED_ARMOUR(PLAYER.PLAYER_PED_ID()) < PLAYER.GET_PLAYER_MAX_ARMOUR(PLAYER.PLAYER_ID()) and PLAYER.IS_PLAYER_DEAD(PLAYER.PLAYER_ID()) == false then
+  if armourCB and PED.GET_PED_ARMOUR(PLAYER.PLAYER_PED_ID()) < PLAYER.GET_PLAYER_MAX_ARMOUR(PLAYER.PLAYER_ID()) and PLAYER.IS_PLAYER_DEAD(PLAYER.PLAYER_ID()) == false and HUD.BUSYSPINNER_IS_ON() == false then
     HSConsoleLogDebug("Adding " .. armourhealamount .. " amount armor")
     PED.ADD_ARMOUR_TO_PED(PLAYER.PLAYER_PED_ID(), armourhealamount)
     armorLoop:sleep(math.floor(armourregenspeed * 1000)) -- 1ms * 1000 to get seconds

--- a/HarmlessScript.lua
+++ b/HarmlessScript.lua
@@ -1013,13 +1013,16 @@ end
 local object = nil
 local objectSpawned = false
 
-function spawnObject() -- Spawns the "air"
+function spawnObject(walkOnAirLoop) -- Spawns the "air" (object)
+  local model = -698352776
+  STREAMING.REQUEST_MODEL(model)
+  while not STREAMING.HAS_MODEL_LOADED(model) do walkOnAirLoop:yield() end -- Wait for the model to load
+
   gui.show_message("Controls", "Left SHIFT = go up\nLeft CTRL = go down")
   HSConsoleLogDebug("Spawning object")
   local player = PLAYER.PLAYER_PED_ID()
   local coords = ENTITY.GET_ENTITY_COORDS(player, true)
-  STREAMING.REQUEST_MODEL(-698352776)
-  object = OBJECT.CREATE_OBJECT(-698352776, coords.x, coords.y, coords.z - 1.2, true, false, false)
+  object = OBJECT.CREATE_OBJECT(model, coords.x, coords.y, coords.z - 1.2, true, false, false)
   ENTITY.SET_ENTITY_ROTATION(object, 270, 0, 0, 1, true)
   ENTITY.SET_ENTITY_VISIBLE(object, false, false)
   ENTITY.SET_ENTITY_ALPHA(object, 0, false)
@@ -1039,21 +1042,20 @@ end
 script.register_looped("HS Walk on Air Loop", function(walkOnAirLoop)
   if walkOnAirCB then
     if not objectSpawned then
-      spawnObject()
+      spawnObject(walkOnAirLoop)
       objectSpawned = true
     end
     if object ~= nil then
       local player = PLAYER.PLAYER_PED_ID()
       local playerCoords = ENTITY.GET_ENTITY_COORDS(player, true)
-      local objectCoords = ENTITY.GET_ENTITY_COORDS(object, true) -- unused local?
-      if PAD.IS_CONTROL_PRESSED(0, 36) then  -- 36 = left CTRl
-        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(object, playerCoords.x, playerCoords.y, playerCoords.z - 1.4, false, false, false, false) -- a little bit smoother
+      if PAD.IS_CONTROL_PRESSED(0, 36) then -- 36 = left CTRl
+        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(object, playerCoords.x, playerCoords.y, playerCoords.z - 1.4, false, false, false, false)
         walkOnAirLoop:sleep(100)
-      elseif PAD.IS_CONTROL_PRESSED(0, 21) then  -- 21 = left SHIFT
-        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(object, playerCoords.x, playerCoords.y, playerCoords.z - 0.7, false, false, false, false)  -- a little bit smoother
+      elseif PAD.IS_CONTROL_PRESSED(0, 21) then -- 21 = left SHIFT
+        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(object, playerCoords.x, playerCoords.y, playerCoords.z - 0.7, false, false, false, false)
         walkOnAirLoop:sleep(50)
       else
-        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(object, playerCoords.x, playerCoords.y, playerCoords.z - 1.075, false, false, false, false)  -- a little bit smoother
+        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(object, playerCoords.x, playerCoords.y, playerCoords.z - 1.075, false, false, false, false)
         walkOnAirLoop:sleep(50)
       end
     end


### PR DESCRIPTION
Changelog window:
- The changelog window dimensions are smaller than the content inside it. With its previous config flags, it was impossible to read the rest of the text and most importantly, it was impossible to close it so you had to reload Harmless's script. I've added a check to the window flags that enables a (x) close button in the title bar so you can close it like a normal window and also enabled mouse scrolling. The scroll bar is currently enabled too because my mouse wheel is broken 😭 and no I'm not buying a new one because I play competitive For Honor and that game cost me like 30 mice and 12 keyboards over a span of 6 years. #!*@ For Honor! 😡
- Replaced an unsupported character (🎉) in the changelog text.
- Disabled the [close] button at the bottom of the window but you can re-enable it if you want.

Self Options > Ragdoll:
- The params for both ragdoll loop and the ragdoll once button were set to never allow the player to get back up so once you use either one of the two options, you'll be stuck in ragdoll. I've adjusted them so the player automatically gets up after a few seconds.

HS Settings > HUD:
- expandedRadarCB: Moved the execution under the checkbox and removed the _while_ loop because it was causing the script to immediately hide the minimap in GTA online whenever it runs. we don't need to loop it because it's basically an on/off switch depending on the state of the checkbox.
- I think the reason why it doesn't work online is that it needs a check before it which is CFX.IS_BIGMAP_ACTIVE() but we can't run CFX natives. I'm not entirely sure though so this might need further testing or just leave it as is. It works fine in SP and it's not really a useful feature in online.